### PR TITLE
Improve getting day by day updates to have a dynamic start and end date

### DIFF
--- a/ocd_backend/extractors/goapi.py
+++ b/ocd_backend/extractors/goapi.py
@@ -44,22 +44,29 @@ class GemeenteOplossingenMeetingsExtractor(GemeenteOplossingenBaseExtractor):
         months = 1  # Max 1 months intervals by default
         if 'months_interval' in self.source_definition:
             months = self.source_definition['months_interval']
+        days = (months / 2.0) * 30
+        # current_start = datetime(2000, 1, 1)  # Start somewhere by default
+        if (months / 2.0) < 1.0:
+            interval_delta = relativedelta(days=days)
+        else:
+            interval_delta = relativedelta(months=months)
 
-        # by default only start for the latest period
-        current_start = datetime.today() - relativedelta(months=months)
+        # current_start = datetime(2000, 1, 1)  # Start somewhere by default
+        current_start = datetime.today() - interval_delta
+
         if 'start_date' in self.source_definition:
             current_start = parse(self.source_definition['start_date'])
 
-        end_date = datetime.today()  + relativedelta(months=months)  # End 1M+
+        end_date = datetime.today() + interval_delta
+
         if 'end_date' in self.source_definition:
             end_date = parse(self.source_definition['end_date'])
-
 
         print "Getting all meetings for %s to %s" % (current_start, end_date,)
 
         meeting_count = 0
         while True:
-            current_end = current_start + relativedelta(months=months)
+            current_end = current_start + interval_delta
 
             # If next current_end exceeds end_date then stop at end_date
             if current_end > end_date:

--- a/ocd_backend/extractors/goapi.py
+++ b/ocd_backend/extractors/goapi.py
@@ -41,17 +41,19 @@ class GemeenteOplossingenMeetingsExtractor(GemeenteOplossingenBaseExtractor):
     """
 
     def run(self):
-        current_start = datetime(2000, 1, 1)  # Start somewhere by default
-        if 'start_date' in self.source_definition:
-            current_start = parse(self.source_definition['start_date'])
-
-        end_date = datetime.today()  # End today by default
-        if 'end_date' in self.source_definition:
-            end_date = parse(self.source_definition['end_date'])
-
         months = 6  # Max 6 months intervals by default
         if 'months_interval' in self.source_definition:
             months = self.source_definition['months_interval']
+
+        # by default only start for the latest period
+        current_start = datetime.today() - relativedelta(months=months)
+        if 'start_date' in self.source_definition:
+            current_start = parse(self.source_definition['start_date'])
+
+        end_date = datetime.today()  + relativedelta(months=months)  # End 1M+
+        if 'end_date' in self.source_definition:
+            end_date = parse(self.source_definition['end_date'])
+
 
         print "Getting all meetings for %s to %s" % (current_start, end_date,)
 
@@ -72,7 +74,7 @@ class GemeenteOplossingenMeetingsExtractor(GemeenteOplossingenBaseExtractor):
                 self.total = len(static_json)
 
                 for meeting in static_json:
-                    yield 'application/json', json.dumps(meeting)
+                    # yield 'application/json', json.dumps(meeting)
                     meeting_count += 1
 
             print "Now processing meetings %s months from %s to %s" % (months, current_start, current_end,)

--- a/ocd_backend/extractors/goapi.py
+++ b/ocd_backend/extractors/goapi.py
@@ -41,7 +41,7 @@ class GemeenteOplossingenMeetingsExtractor(GemeenteOplossingenBaseExtractor):
     """
 
     def run(self):
-        months = 6  # Max 6 months intervals by default
+        months = 1  # Max 1 months intervals by default
         if 'months_interval' in self.source_definition:
             months = self.source_definition['months_interval']
 
@@ -74,7 +74,7 @@ class GemeenteOplossingenMeetingsExtractor(GemeenteOplossingenBaseExtractor):
                 self.total = len(static_json)
 
                 for meeting in static_json:
-                    # yield 'application/json', json.dumps(meeting)
+                    yield 'application/json', json.dumps(meeting)
                     meeting_count += 1
 
             print "Now processing meetings %s months from %s to %s" % (months, current_start, current_end,)

--- a/ocd_backend/extractors/ibabs.py
+++ b/ocd_backend/extractors/ibabs.py
@@ -68,17 +68,19 @@ class IBabsMeetingsExtractor(IBabsBaseExtractor):
                 self.source_definition['sitename']).Meetingtypes[0]}
 
     def run(self):
-        current_start = datetime(2000, 1, 1)  # Start somewhere by default
-        if 'start_date' in self.source_definition:
-            current_start = parse(self.source_definition['start_date'])
-
-        end_date = datetime.today()  # End today by default
-        if 'end_date' in self.source_definition:
-            end_date = parse(self.source_definition['end_date'])
-
         months = 6  # Max 6 months intervals by default
         if 'months_interval' in self.source_definition:
             months = self.source_definition['months_interval']
+
+        # current_start = datetime(2000, 1, 1)  # Start somewhere by default
+        current_start = datetime.today() - relativedelta(months=months)
+        if 'start_date' in self.source_definition:
+            current_start = parse(self.source_definition['start_date'])
+
+        end_date = datetime.today()  + relativedelta(months=months)  # End 1M+
+        if 'end_date' in self.source_definition:
+            end_date = parse(self.source_definition['end_date'])
+
 
         print "Getting all meetings for %s to %s" % (current_start, end_date,)
 

--- a/ocd_backend/extractors/ibabs.py
+++ b/ocd_backend/extractors/ibabs.py
@@ -71,13 +71,21 @@ class IBabsMeetingsExtractor(IBabsBaseExtractor):
         months = 1  # Max 1 months intervals by default
         if 'months_interval' in self.source_definition:
             months = self.source_definition['months_interval']
+        days = (months / 2.0) * 30
+        # current_start = datetime(2000, 1, 1)  # Start somewhere by default
+        if (months / 2.0) < 1.0:
+            interval_delta = relativedelta(days=days)
+        else:
+            interval_delta = relativedelta(months=months)
 
         # current_start = datetime(2000, 1, 1)  # Start somewhere by default
-        current_start = datetime.today() - relativedelta(months=months)
+        current_start = datetime.today() - interval_delta
+
         if 'start_date' in self.source_definition:
             current_start = parse(self.source_definition['start_date'])
 
-        end_date = datetime.today()  + relativedelta(months=months)  # End 1M+
+        end_date = datetime.today() + interval_delta
+
         if 'end_date' in self.source_definition:
             end_date = parse(self.source_definition['end_date'])
 
@@ -88,7 +96,7 @@ class IBabsMeetingsExtractor(IBabsBaseExtractor):
         meeting_item_count = 0
 
         while True:
-            current_end = current_start + relativedelta(months=months)
+            current_end = current_start + interval_delta
 
             meetings = self.client.service.GetMeetingsByDateRange(
                 Sitename=self.source_definition['sitename'],

--- a/ocd_backend/extractors/ibabs.py
+++ b/ocd_backend/extractors/ibabs.py
@@ -68,7 +68,7 @@ class IBabsMeetingsExtractor(IBabsBaseExtractor):
                 self.source_definition['sitename']).Meetingtypes[0]}
 
     def run(self):
-        months = 6  # Max 6 months intervals by default
+        months = 1  # Max 1 months intervals by default
         if 'months_interval' in self.source_definition:
             months = self.source_definition['months_interval']
 


### PR DESCRIPTION
Previous improvements introduced a way of splitting up getting meetings and meeting items by splitting in a predefined number of months. However, that still required manual updates of the configurations to specify the start date (if not specified, a default start date of 1st Jan 2000 was assumed). This patch improves upon that by looking back and ahead for a predefined set of months, so we do not have to edit the files anymore for day to day updates.