### PR TITLE
Multiple pipelines

### DIFF
--- a/ocd_backend/__init__.py
+++ b/ocd_backend/__init__.py
@@ -4,9 +4,12 @@ from ocd_backend.settings import CELERY_CONFIG
 
 celery_app = Celery('ocd_backend', include=[
     'ocd_backend.extractors',
+    'ocd_backend.extractors.ggm',
     'ocd_backend.transformers',
+    'ocd_backend.transformers.ggm',
     'ocd_backend.enrichers.media_enricher',
     'ocd_backend.loaders',
+    'ocd_backend.loaders.ggm',
     'ocd_backend.tasks'
 ])
 

--- a/ocd_backend/extractors/ggm.py
+++ b/ocd_backend/extractors/ggm.py
@@ -1,0 +1,61 @@
+import os
+import json
+from base64 import b64encode
+
+from ocd_backend import celery_app
+from ocd_backend.extractors import BaseExtractor, HttpRequestMixin
+
+
+class GegevensmagazijnBaseExtractor(BaseExtractor, HttpRequestMixin):
+
+    def __init__(self, **kwargs):
+        super(GegevensmagazijnBaseExtractor, self).__init__(source_definition=kwargs['source_definition'])
+        self.http_session.headers['Authorization'] = 'Basic %s' % b64encode('%s:%s' % (self.source_definition['ggm_username'], self.source_definition['ggm_password']))
+        self.base_url = self.source_definition['base_url']
+
+
+class GegevensmagazijnEntityExtractor(HttpRequestMixin, celery_app.Task):
+
+    def run(self, item, **kwargs):
+        self.source_definition = kwargs['source_definition']
+        self.http_session.headers['Authorization'] = 'Basic %s' % b64encode('%s:%s' % (self.source_definition['ggm_username'], self.source_definition['ggm_password']))
+        self.http_session.headers['Accept'] = 'application/xml; charset="utf-8"'
+        resp = self.http_session.get(item)
+        return 'application/xml', resp.content
+
+
+class GegevensmagazijnFeedExtractor(GegevensmagazijnBaseExtractor):
+
+    def run(self, piket=None, **kwargs):
+        while True:
+            if piket:
+                print "Downloading:", piket
+                resp = self.http_session.get(u'%s&piket=%s' % (self.base_url, piket))
+            elif os.environ.get('GGM_PIKET'):
+                print "Downloading using env:", os.environ.get('GGM_PIKET')
+                resp = self.http_session.get(
+                    u'%s&piket=%s' % (self.base_url, os.environ['GGM_PIKET']))
+            else:
+                print "Downloading the base_url"
+                resp = self.http_session.get(self.base_url)
+
+            if resp.status_code == 200:
+                feed = json.loads(resp.content)
+
+                for entry in feed['entries']:
+                    yield (entry['content']['src'],)
+
+                try:
+                    next_piket = [link["href"] for link in feed['links'] if link['rel'] == 'next'][0]
+                    os.environ['GGM_PIKET'] = next_piket.split('=')[-1]
+                    os.putenv('GGM_PIKET', next_piket.split('=')[-1])
+                except:
+                    if 'resume' in [link['rel'] for link in feed['links']]:
+                        print "DONE!!!"
+                        break
+                    else:
+                        raise Exception("No next piket or resume found")
+            else:
+                print resp.status_code
+                #raise  # todo fix this!
+                break

--- a/ocd_backend/items/ggm.py
+++ b/ocd_backend/items/ggm.py
@@ -1,0 +1,196 @@
+from hashlib import sha1
+import iso8601
+
+from ocd_backend.items.popolo import EventItem, MotionItem, PersonItem
+
+
+class GegevensmagazijnBaseItem(object):
+
+    def _xpath(self, path):
+        return self.original_item.xpath(path)
+
+    def _get_current_permalink(self):
+        return u'https://gegevensmagazijn.tweedekamer.nl/REST/Entiteiten/%s' % self.get_object_id()
+
+    def get_object_id(self):
+        raise NotImplementedError
+
+    def get_original_object_id(self):
+        return unicode(self._xpath("string(/*/@id)"))
+
+    def get_original_object_urls(self):
+        return {"xml": self._get_current_permalink()}
+
+    def get_rights(self):
+        return u'undefined'
+
+    def get_collection(self):
+        return unicode(self.source_definition['index_name'])
+
+    def get_index_data(self):
+        return {}
+
+    def get_all_text(self):
+        text_items = []
+        return u' '.join(text_items)
+
+
+class Meeting(GegevensmagazijnBaseItem, EventItem):
+
+    def get_object_id(self):
+        return self.get_meeting_id()
+
+    def get_meeting_id(self):
+        hash_content = u'meeting-%s' % self.get_original_object_id()
+        return unicode(sha1(hash_content.decode('utf8')).hexdigest())
+
+    def get_combined_index_data(self):
+        combined_index_data = {}
+
+        #committees = self._get_committees()
+        current_permalink = self._get_current_permalink()
+
+        combined_index_data['id'] = unicode(self.get_object_id())
+
+        combined_index_data['hidden'] = self.source_definition['hidden']
+
+        combined_index_data['name'] = unicode(self._xpath("string(/activiteit/onderwerp)"))
+        #combined_index_data['start_date'] = iso8601.parse_date(self._xpath("string(/activiteit/planning/begin)"))
+        #print iso8601.parse_date(self._xpath("string(/activiteit/planning/einde)"))
+        #combined_index_data['end_date'] = self._xpath("string(/activiteit/planning/einde)")
+        combined_index_data['location'] = unicode(self._xpath("string(/activiteit/locatie)"))
+        combined_index_data['classification'] = u'event_item'
+
+        combined_index_data['children'] = [item.xpath("string(@id)") for item in self._xpath("/activiteit/agendapunt")]
+        combined_index_data['attendees'] = [item.xpath("string(@id)") for item in self._xpath("/activiteit/deelnemer")]
+        combined_index_data['cancelled'] = {'id': item.xpath("string(@id)") for item in self._xpath("/activiteit/afgemeld")}
+
+        for item in self._xpath("/activiteit/kamers/*"):
+            combined_index_data['organizations'] = {'id': item.xpath("string(@id)"), 'name': item.xpath("string(name())")}
+
+        # Status might be with or without a capital
+        if self._xpath("contains(/activiteit/status, 'itgevoerd')"):  # Uitgevoerd
+            combined_index_data['status'] = u'completed'
+        elif self._xpath("contains(/activiteit/status, 'ervplaats')"):  # Verplaatst
+            combined_index_data['status'] = u'postponed'
+        elif self._xpath("contains(/activiteit/status, 'epland')"):  # Gepland
+            combined_index_data['status'] = u'tentative'
+        elif self._xpath("contains(/activiteit/status, 'eannuleerd')"):  # Geannuleerd
+            combined_index_data['status'] = u'cancelled'
+
+        combined_index_data['identifiers'] = [
+            {
+                'identifier': self.get_original_object_id(),
+                'scheme': u'Gegevensmagazijn'
+            },
+            {
+                'identifier': self._xpath("string(/activiteit/vrsNummer)"),
+                'scheme': u'vrsnummer'
+            },
+            {
+                'identifier': self._xpath("string(/activiteit/nummer)"),
+                'scheme': u'nummer'
+            },
+            {
+                'identifier': self.get_object_id(),
+                'scheme': u'ORI'
+            }
+        ]
+
+        # try:
+        #     combined_index_data['organization'] = committees[
+        #         self.original_item['dmu']['id']]
+        # except KeyError:
+        #     pass
+
+        # combined_index_data['organization_id'] = unicode(
+        #     self.original_item['dmu']['id'])
+
+        combined_index_data['status'] = u'confirmed'
+        combined_index_data['sources'] = [
+            {
+                'url': current_permalink,
+                'note': u''
+            }
+        ]
+
+        # if 'items' in self.original_item:
+        #     combined_index_data['children'] = [
+        #         self.get_meeting_id(mi) for mi in self.original_item['items']]
+
+        combined_index_data['sources'] = []
+
+        return combined_index_data
+
+
+class Motion(GegevensmagazijnBaseItem, MotionItem):
+
+    def get_object_id(self):
+        return self.get_motion_id()
+
+    def get_motion_id(self):
+        hash_content = u'motion-%s' % self.get_original_object_id()
+        return unicode(sha1(hash_content.decode('utf8')).hexdigest())
+
+    def get_combined_index_data(self):
+        combined_index_data = {}
+        return combined_index_data
+
+
+class Person(GegevensmagazijnBaseItem, PersonItem):
+
+    def get_object_id(self):
+        return self.get_person_id()
+
+    def get_person_id(self):
+        hash_content = u'person-%s' % self.get_original_object_id()
+        return unicode(sha1(hash_content.decode('utf8')).hexdigest())
+
+    def get_combined_index_data(self):
+        combined_index_data = {}
+
+        combined_index_data['id'] = unicode(self.get_object_id())
+
+        combined_index_data['hidden'] = self.source_definition['hidden']
+
+        combined_index_data['honorific_prefix'] = unicode(self._xpath("string(/persoon/titels)"))
+        combined_index_data['family_name'] = unicode(self._xpath("string(/persoon/achternaam)"))
+        combined_index_data['given_name'] = unicode(self._xpath("string(/persoon/voornamen)"))
+        combined_index_data['name'] = u' '.join([x for x in [self._xpath("string(/persoon/roepnaam)"), self._xpath("string(/persoon/tussenvoegsel)"), combined_index_data['family_name']] if x != ''])
+
+        gender = self._xpath("string(/persoon/geslacht)")
+        if gender == 'man':
+            combined_index_data['gender'] = u"male"
+        elif gender == 'vrouw':
+            combined_index_data['gender'] = u"female"
+
+        if self._xpath("string(/persoon/geboortdatum)"):
+            combined_index_data['birth_date'] = iso8601.parse_date(self._xpath("string(/persoon/geboortdatum)"))
+        if self._xpath("string(/persoon/overlijdensdatum)"):
+            combined_index_data['death_date'] = iso8601.parse_date(self._xpath("string(/persoon/overlijdensdatum)"))
+
+        combined_index_data['national_identity'] = unicode(self._xpath("string(/persoon/geboorteland)"))
+        combined_index_data['email'] = unicode(self._xpath("string(/persoon/contactinformatie[soort='E-mail']/waarde)"))
+        combined_index_data['links'] = [unicode(self._xpath("string(/persoon/contactinformatie[soort='Website']/waarde)"))]
+
+        combined_index_data['identifiers'] = [
+            {
+                'identifier': self.get_original_object_id(),
+                'scheme': u'Gegevensmagazijn'
+            },
+            {
+                'identifier': unicode(self.get_object_id()),
+                'scheme': u'ORI'
+            }
+        ]
+
+        # combined_index_data['memberships'] = [
+        #     {
+        #         'label': role,
+        #         'role': role,
+        #         'person_id': combined_index_data['id'],
+        #         'organization_id': council_id,
+        #         'organization': council_obj
+        #     }
+        # ]
+        return combined_index_data

--- a/ocd_backend/loaders/ggm.py
+++ b/ocd_backend/loaders/ggm.py
@@ -1,0 +1,86 @@
+import json
+
+from ocd_backend.loaders import BaseLoader
+from ocd_backend.extractors import HttpRequestMixin
+from ocd_backend.exceptions import ConfigurationError
+from ocd_backend.utils.misc import json_datetime
+
+from elasticsearch import ConflictError
+from ocd_backend import settings
+from ocd_backend.es import elasticsearch
+from ocd_backend.log import get_source_logger
+
+log = get_source_logger('loader')
+
+
+class GegevensmagazijnElasticsearchLoader(BaseLoader):
+
+    def run(self, args, **kwargs):
+        self.source_definition = kwargs['source_definition']
+
+        self.current_index_name = kwargs.get('current_index_name')
+        self.index_name = kwargs.get('new_index_name')
+        self.alias = kwargs.get('index_alias')
+
+        if not self.index_name:
+            raise ConfigurationError('The name of the index is not provided')
+
+        for arg in args:
+            self.doc_type = arg[-1]
+            super(GegevensmagazijnElasticsearchLoader, self).run(arg[:-1], **kwargs)
+        return True
+
+    def load_item(
+        self, combined_object_id, object_id, combined_index_doc, doc
+    ):
+        log.info('Indexing document id: %s' % object_id)
+        elasticsearch.index(index=settings.COMBINED_INDEX,
+                            doc_type=self.doc_type, id=combined_object_id,
+                            body=combined_index_doc)
+
+        # Index documents into new index
+        elasticsearch.index(index=self.index_name, doc_type=self.doc_type,
+                            body=doc, id=object_id)
+
+        m_url_content_types = {}
+        if 'media_urls' in doc['enrichments']:
+            for media_url in doc['enrichments']['media_urls']:
+                if 'content_type' in media_url:
+                    m_url_content_types[media_url['original_url']] = \
+                        media_url['content_type']
+
+        # For each media_urls.url, add a resolver document to the
+        # RESOLVER_URL_INDEX
+        if 'media_urls' in doc:
+            for media_url in doc['media_urls']:
+                url_hash = media_url['url'].split('/')[-1]
+                url_doc = {
+                    'original_url': media_url['original_url']
+                }
+
+                if media_url['original_url'] in m_url_content_types:
+                    url_doc['content_type'] = \
+                        m_url_content_types[media_url['original_url']]
+
+                try:
+                    elasticsearch.create(index=settings.RESOLVER_URL_INDEX,
+                                         doc_type='url', id=url_hash,
+                                         body=url_doc)
+                except ConflictError:
+                    log.debug('Resolver document %s already exists' % url_hash)
+
+
+class GegevensmagazijnLDPLoader(BaseLoader, HttpRequestMixin):
+
+    def run(self, args, **kwargs):
+        self.source_definition = kwargs['source_definition']
+
+        for arg in args:
+            self.doc_type = arg[-1]
+            super(GegevensmagazijnLDPLoader, self).run(arg[:-1], **kwargs)
+
+    def load_item(self, combined_object_id, object_id, combined_index_doc, doc):
+        data = json.dumps(doc, default=json_datetime)
+        self.http_session.headers['Content-Type'] = 'application/json'
+        self.http_session.headers['Link'] = '<http://json-ld.org/contexts/%s.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' % self.doc_type
+        #print self.http_session.post(ldp_loader_url, data=data)

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -47,63 +47,49 @@ def setup_pipeline(source_definition):
             now=datetime.utcnow().strftime('%Y%m%d%H%M%S')
         )
 
-    extractor = load_object(source_definition['extractor'])(source_definition)
-    transformer = load_object(source_definition['transformer'])()
-    enrichers = [(load_object(enricher[0])(), enricher[1]) for enricher in
-                 source_definition['enrichers']]
-    loader = load_object(source_definition['loader'])()
-
     # Parameters that are passed to each task in the chain
     params = {
         'run_identifier': 'pipeline_{}'.format(uuid4().hex),
         'current_index_name': current_index_name,
         'new_index_name': new_index_name,
-        'index_alias': index_alias
+        'index_alias': index_alias,
+        'source_definition': source_definition
     }
 
     celery_app.backend.set(params['run_identifier'], 'running')
     run_identifier_chains = '{}_chains'.format(params['run_identifier'])
 
+    first_step = source_definition['chain'].pop(0)
     try:
-        for item in extractor.run():
-            # Generate an identifier for each chain, and record that in
-            # {}_chains, so that we can know for sure when all tasks
-            # from an extractor have finished
-            params['chain_id'] = uuid4().hex
-            celery_app.backend.add_value_to_set(set_name=run_identifier_chains,
-                                                value=params['chain_id'])
+        for item in load_object(first_step)(**params).run():
+            step_chain = chain()
 
-            item_chain = chain()
+            for step in source_definition['chain']:
+                # Generate an identifier for each chain, and record that in
+                # {}_chains, so that we can know for sure when all tasks
+                # from an extractor have finished
 
-            # Tranform
-            item_chain |= transformer.s(
-                *item,
-                source_definition=source_definition,
-                **params
-            )
+                params['chain_id'] = uuid4().hex
+                celery_app.backend.add_value_to_set(set_name=run_identifier_chains,
+                                                    value=params['chain_id'])
 
-            # Enrich
-            for enricher_task, enricher_settings in enrichers:
-                item_chain |= enricher_task.s(
-                    source_definition=source_definition,
-                    enricher_settings=enricher_settings,
+                step_class = load_object(step)()
+
+                step_chain |= step_class.s(
+                    *item,
                     **params
                 )
 
-            # Load
-            item_chain |= loader.s(
-                source_definition=source_definition,
-                **params
-            )
+                item = []
 
-            item_chain.delay()
+            step_chain.delay()
     except:
         logger.error('An exception has occured in the "{extractor}" extractor. '
                      'Setting status of run identifier "{run_identifier}" to '
                      '"error".'
-                     .format(index=new_index_name,
+                     .format(index=params['new_index_name'],
                              run_identifier=params['run_identifier'],
-                             extractor=source_definition['extractor']))
+                             extractor=first_step))
 
         celery_app.backend.set(params['run_identifier'], 'error')
         raise

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -86,6 +86,9 @@ def setup_pipeline(source_definition):
                 step_class = load_object(step)(source_definition)
                 step_chain |= step_class.s(*item, **params)
 
+            # FIXME: the transformer actually drives the item transformer
+            # which is what we want to do multiple times here... not the
+            # transformer itself ...
             for step in transformers:
                 step_class = load_object(step)()
                 step_chain |= step_class.s(

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -64,15 +64,17 @@ def setup_pipeline(source_definition):
     pipelines = source_definition.get('pipelines', None) or [source_definition]
     extractors = list(set([p['extractor'] for p in pipelines]))
 
-    # adjusted source definitionsv per pipeline. This way you can for example
-    # change the index on a pipeline basis
     pipeline_definitions = {}
     pipeline_transformers = {}
     pipeline_enrichers = {}
     pipeline_loaders = {}
     for pipeline in pipelines:
+        # adjusted source definitionsv per pipeline. This way you can for
+        # example change the index on a pipeline basis
         pipeline_definitions[pipeline['id']] = deepcopy(source_definition)
         pipeline_definitions[pipeline['id']].update(pipeline)
+
+        # initialize the ETL classes, per pipeline
         pipeline_transformers[pipeline['id']] = load_object(
             pipeline['transformer'])()
         pipeline_enrichers[pipeline['id']] = [
@@ -116,6 +118,7 @@ def setup_pipeline(source_definition):
                             **params
                         )
 
+                    # multiple loaders to enable to save to different stores
                     initialized_loaders = []
                     for loader in pipeline_loaders[pipeline['id']]:
                         initialized_loaders.append(loader.s(

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -69,6 +69,9 @@ def setup_pipeline(source_definition):
     pipeline_enrichers = {}
     pipeline_loaders = {}
     for pipeline in pipelines:
+        if 'id' not in pipeline:
+            raise ConfigurationError("Each pipeline must have an id field.")
+
         # adjusted source definitionsv per pipeline. This way you can for
         # example change the index on a pipeline basis
         pipeline_definitions[pipeline['id']] = deepcopy(source_definition)

--- a/ocd_backend/sources/ggm.json
+++ b/ocd_backend/sources/ggm.json
@@ -1,10 +1,12 @@
 [
   {
     "id": "gegevensmagazijn",
-    "chain": [
+    "extractors": [
       "ocd_backend.extractors.ggm.GegevensmagazijnFeedExtractor",
-      "ocd_backend.extractors.ggm.GegevensmagazijnEntityExtractor",
-      "ocd_backend.transformers.ggm.GegevensmagazijnBaseTransformer",
+      "ocd_backend.extractors.ggm.GegevensmagazijnEntityExtractor"
+    ],
+    "transformer": "ocd_backend.transformers.ggm.GegevensmagazijnBaseTransformer",
+    "loaders": [
       "ocd_backend.loaders.ggm.GegevensmagazijnElasticsearchLoader"
     ],
     "cleanup": "ocd_backend.tasks.CleanupElasticsearch",

--- a/ocd_backend/sources/ggm.json
+++ b/ocd_backend/sources/ggm.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": "gegevensmagazijn",
+    "chain": [
+      "ocd_backend.extractors.ggm.GegevensmagazijnFeedExtractor",
+      "ocd_backend.extractors.ggm.GegevensmagazijnEntityExtractor",
+      "ocd_backend.transformers.ggm.GegevensmagazijnBaseTransformer",
+      "ocd_backend.loaders.ggm.GegevensmagazijnElasticsearchLoader"
+    ],
+    "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
+    "hidden": false,
+    "index_name": "ggm",
+    "keep_index_on_update": true,
+    "base_url": "https://gegevensmagazijn.tweedekamer.nl/REST/Feed.json?filter=persoon",
+    "ggm_username": "joepmeindertsma",
+    "ggm_password": "pb2XeZ*D3sDXDUq4Q1Xt",
+    "ldp_loader_url": "https://localhost:8082",
+    "mapping": {
+      "activiteit": {
+        "doc_type": "event",
+        "item_class": "ocd_backend.items.ggm.Meeting",
+        "jsonld": "http://www.popoloproject.com/contexts/event.jsonld",
+        "sub_items": [
+          "/activiteit/agendapunt/besluit"
+        ]
+      },
+      "besluit": {
+        "doc_type": "motion",
+        "item_class": "ocd_backend.items.ggm.Motion",
+        "jsonld": "http://www.popoloproject.com/contexts/motion.jsonld"
+      },
+      "persoon": {
+        "doc_type": "person",
+        "item_class": "ocd_backend.items.ggm.Person",
+        "jsonld": "http://www.popoloproject.com/contexts/person.jsonld"
+      }
+    }
+  }
+]

--- a/ocd_backend/sources/goirle.json
+++ b/ocd_backend/sources/goirle.json
@@ -44,10 +44,16 @@
   {
       "id": "goirle_popit_organizations",
       "extractor": "ocd_backend.extractors.popit.PopItExtractor",
-      "transformer": "ocd_backend.transformers.BaseTransformer",
-      "item": "ocd_backend.items.popit.PopitOrganisationItem",
+      "transformers": [
+        "ocd_backend.transformers.BaseTransformer",
+        "ocd_backend.transformers.BaseTransformer"],
+      "items": [
+        "ocd_backend.items.popit.PopitOrganisationItem",
+        "ocd_backend.items.popit.PopitOrganisationItem"],
       "enrichers": [],
-      "loader": "ocd_backend.loaders.ElasticsearchLoader",
+      "loaders": [
+        "ocd_backend.loaders.ElasticsearchLoader",
+        "ocd_backend.loaders.DummyLoader"],
       "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
       "hidden": false,
       "index_name": "goirle",

--- a/ocd_backend/sources/goirle.json
+++ b/ocd_backend/sources/goirle.json
@@ -43,17 +43,18 @@
   },
   {
       "id": "goirle_popit_organizations",
-      "extractor": "ocd_backend.extractors.popit.PopItExtractor",
-      "transformers": [
-        "ocd_backend.transformers.BaseTransformer",
-        "ocd_backend.transformers.BaseTransformer"],
-      "items": [
-        "ocd_backend.items.popit.PopitOrganisationItem",
-        "ocd_backend.items.popit.PopitOrganisationItem"],
-      "enrichers": [],
-      "loaders": [
-        "ocd_backend.loaders.ElasticsearchLoader",
-        "ocd_backend.loaders.DummyLoader"],
+      "pipelines": [
+        {
+          "id": "pipeline_normal",
+          "extractor": "ocd_backend.extractors.popit.PopItExtractor",
+          "transformer": "ocd_backend.transformers.BaseTransformer",
+          "item": "ocd_backend.items.popit.PopitOrganisationItem",
+          "enrichers": [],
+          "loaders": [
+            "ocd_backend.loaders.ElasticsearchLoader",
+            "ocd_backend.loaders.DummyLoader"]
+        }
+      ],
       "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
       "hidden": false,
       "index_name": "goirle",

--- a/ocd_backend/transformers/ggm.py
+++ b/ocd_backend/transformers/ggm.py
@@ -1,0 +1,71 @@
+from ocd_backend.transformers import BaseTransformer
+from ocd_backend.utils.misc import load_object, strip_namespaces
+
+
+class GegevensmagazijnBaseTransformer(BaseTransformer):
+
+    def run(self, *args, **kwargs):
+        """Start transformation of a single item.
+
+        This method is called by the extractor and expects args to
+        contain the content-type and the original item (as a string).
+        Kwargs should contain the ``source_definition`` dict.
+
+        :type raw_item_content_type: string
+        :param raw_item_content_type: the content-type of the data
+            retrieved from the source (e.g. ``application/json``)
+        :type raw_item: string
+        :param raw_item: the data in it's original format, as retrieved
+            from the source (as a string)
+
+        item
+
+        :param source_definition: The configuration of a single source in
+            the form of a dictionary (as defined in the settings).
+        :type source_definition: dict.
+        :returns: the output of :py:meth:`~BaseTransformer.transform_item`
+        """
+
+        # Vaag gebeuren met dubbele nesting waardoor *args niet meer werkt
+        args = args[0]
+
+        self.source_definition = kwargs['source_definition']
+
+        if 'item' in kwargs:
+            item = kwargs['item']
+        else:
+            item = self.deserialize_item(*args)
+
+        return self.transform_item(*args, item=strip_namespaces(item))
+
+    def transform_item(self, raw_item_content_type, raw_item, item):
+        root_name = item.xpath("local-name()")
+
+        if root_name in self.source_definition['mapping']:
+            item_source = self.source_definition['mapping'][root_name]
+            item_class = item_source['item_class']
+        else:
+            #raise Exception("item_class was not found for %s in the source_definition mapping!" % root_name)
+            print "%s not in mapping" % root_name
+            return [] # <-- kan dit voor problemen zorgen?
+
+        items = []
+        if 'sub_items' in item_source:
+            for path in item_source['sub_items']:
+                for subitem in item.xpath(path):
+                    items += self.transform_item(raw_item_content_type, raw_item, subitem)
+
+        item = load_object(item_class)(self.source_definition, raw_item_content_type,
+                               raw_item, item)
+
+        self.add_resolveable_media_urls(item)
+
+        doc_type = item_source['doc_type']
+
+        return [(
+            item.get_combined_object_id(),
+            item.get_object_id(),
+            item.get_combined_index_doc(),
+            item.get_index_doc(),
+            doc_type
+        )] + items


### PR DESCRIPTION
Modifies the OCD stack so we can have mutiple pipelines per source. This is done by adding a `pipelines` key in the source, which holds an array of objects, which are later on merged with the source definition to form a pipeline specific configuration. This allows for backwards compatibility, but also for flexibility (Like changing the `index_name` per pipeline. In addition, a source can have `loaders` now, instead of just a loader to allow for saving to different stores (And all else being the same). A sample config can [be seen here](https://github.com/openstate/open-raadsinformatie/blob/ggm_parallel_loaders/ocd_backend/sources/goirle.json#L46)

Note: This does not implement second stage extractors yet.