### PR TITLE
issue-139

### DIFF
--- a/ocd_backend/items/goapi_meeting.py
+++ b/ocd_backend/items/goapi_meeting.py
@@ -76,8 +76,7 @@ class GemeenteOplossingenMeetingItem(BaseItem):
         event.organization.merge(collection=self.source_definition['key'])
 
         # Attach the meeting to the committee node. GO always lists either the name of the committee or 'Raad'
-        # if it is a non-committee meeting so we can attach it to a committee node without any extra checks
-        # as opposed to iBabs
+        # if it is a non-committee meeting so we can attach it to a committee node without any extra checks.
         event.committee = Organization(self.original_item[u'dmu'][u'id'], **source_defaults)
         event.committee.has_organization_name = TopLevelOrganization(self.source_definition['key'], **source_defaults)
         event.committee.has_organization_name.merge(collection=self.source_definition['key'])

--- a/ocd_backend/sources/osi.go.yaml
+++ b/ocd_backend/sources/osi.go.yaml
@@ -26,21 +26,6 @@ _entities: &entities
     prefix: "{classification}"
     item_xpath: //
 
-# The Council is automatically created in GOAPI when processing meetings (see
-# items.goapi_meeting.GemeenteOplossingenMeetingItem)
-#
-#  - &province_council
-#    <<: *entity_defaults
-#    entity: council
-#    doc_type: organizations
-#    extractor: ocd_backend.extractors.almanak.AlmanakOrganisationsExtractor
-#    extractor_xpath: "//div[@id=\"content\"]/ul//li/a/text()"
-#    item: ocd_backend.items.organisations.AlmanakOrganisationItem
-#    file_url: https://almanak.overheid.nl/{almanak_id}/a
-#    classification: Council
-#    prefix: "{classification}"
-#    item_xpath: //
-
   - &committees
     <<: *entity_defaults
     entity: committees

--- a/ocd_backend/sources/osi.gv.yaml
+++ b/ocd_backend/sources/osi.gv.yaml
@@ -26,17 +26,6 @@ _entities: &entities
     classification: Province
     prefix: "{classification}"
 
-#  - &province_council
-#    <<: *entity_defaults
-#    entity: council
-#    doc_type: organizations
-#    extractor: ocd_backend.extractors.almanak.AlmanakOrganisationsExtractor
-#    extractor_xpath: "//div[@id=\"content\"]/ul//li/a/text()"
-#    item: ocd_backend.items.organisations.AlmanakOrganisationItem
-#    file_url: https://almanak.overheid.nl/{almanak_id}/a
-#    classification: Council
-#    prefix: "{classification}"
-
   - &organizations
     <<: *entity_defaults
     entity: organizations

--- a/ocd_backend/sources/osi.ibabs.yaml
+++ b/ocd_backend/sources/osi.ibabs.yaml
@@ -46,17 +46,6 @@ _entities: &entities
     classification: Province
     prefix: "{classification}"
 
-#  - &province_council
-#    <<: *entity_defaults
-#    entity: council
-#    doc_type: organizations
-#    extractor: ocd_backend.extractors.almanak.AlmanakOrganisationsExtractor
-#    item: ocd_backend.items.organisations.AlmanakOrganisationItem
-#    file_url: https://almanak.overheid.nl/{almanak_id}/a
-#    item_xpath: "//div[@id=\"content\"]/ul//li/a/text()"
-#    classification: Council
-#    prefix: "{classification}"
-
   - &committees
     <<: *entity_defaults
     entity: committees
@@ -121,7 +110,6 @@ _entities_voting: &entities_voting
     council_members_count: 1
     reverse_chronological: true
     max_processed_meetings: 1
-
 
   - &persons_voting
     <<: *entity_defaults


### PR DESCRIPTION
Removed councils as extractable entities. Councils will only be created during meeting creation if the given source supplies the relevant information.