### PR TITLE
Disable Tika until it is fixed

### DIFF
--- a/ocd_backend/utils/file_parsing.py
+++ b/ocd_backend/utils/file_parsing.py
@@ -33,12 +33,15 @@ def file_parser(fname, pages=None):
             # reraise everything
             raise
     else:
-        try:
-            content = parser.from_file(fname)['content']
-            return (content or '').encode('UTF-8')
-        except:
-            # reraise everything
-            raise
+        # This code path is disabled until the Tika service is fixed (see issue 178)
+
+        # try:
+        #     content = parser.from_file(fname)['content']
+        #     return (content or '').encode('UTF-8')
+        # except:
+        #     # reraise everything
+        #     raise
+        pass
 
 
 class FileToTextMixin(object):


### PR DESCRIPTION
This is a hotfix for production to disable the enricher code path that tries to use Tika to parse PDFs that can't be parsed by poppler. Tika needs to be fixed first (#178), so for now I want to disable it because while it is enabled there are enricher jobs endlessly being retried and clogging up the queue.