### PR TITLE
Allow more ES endpoints

### DIFF
--- a/deployment/endpoints/production.yaml
+++ b/deployment/endpoints/production.yaml
@@ -41,168 +41,168 @@ paths:
         200:
           description: ""
 
-    /_cat/indices/{index}:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint displaying the indices that match the index filter.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html for more information.
-        operationId: "elastic_indices_get_index"
-        parameters:
-          - $ref: "#/parameters/index"
-        responses:
-          200:
-            description: ""
+  /_cat/indices/{index}:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint displaying the indices that match the index filter.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html for more information.
+      operationId: "elastic_indices_get_index"
+      parameters:
+        - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
 
-    /_cat/health:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Health is a terse, one-line representation of the same information from /_cluster/health.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-health.html for more information.
-        operationId: "elastic_health_get"
-        responses:
-          200:
-            description: ""
+  /_cat/health:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Health is a terse, one-line representation of the same information from /_cluster/health.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-health.html for more information.
+      operationId: "elastic_health_get"
+      responses:
+        200:
+          description: ""
 
-    /_search:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for searching.
-          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-        operationId: "elastic_search_get"
-        responses:
-          200:
-            description: ""
-      post:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for searching.
-          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-        operationId: "elastic_search_post"
-        responses:
-          200:
-            description: ""
+  /_search:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for searching.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+      operationId: "elastic_search_get"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for searching.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+      operationId: "elastic_search_post"
+      responses:
+        200:
+          description: ""
 
-    /_msearch:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for multi search.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-        operationId: "elastic_msearch_get"
-        responses:
-          200:
-            description: ""
-      post:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for multi search.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-        operationId: "elastic_msearch_post"
-        responses:
-          200:
-            description: ""
+  /_msearch:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for multi search.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+      operationId: "elastic_msearch_get"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for multi search.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+      operationId: "elastic_msearch_post"
+      responses:
+        200:
+          description: ""
 
-    /{index}/_search:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for searching.
-          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-        operationId: "elastic_search_index_get"
-        parameters:
-          - $ref: "#/parameters/index"
-        responses:
-          200:
-            description: ""
-      post:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for searching.
-          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-        operationId: "elastic_search_index_post"
-        parameters:
-          - $ref: "#/parameters/index"
-        responses:
-          200:
-            description: ""
+  /{index}/_search:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for searching.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+      operationId: "elastic_search_index_get"
+      parameters:
+        - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for searching.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+      operationId: "elastic_search_index_post"
+      parameters:
+        - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
 
-    /{index}/_msearch:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for multi search.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-        operationId: "elastic_msearch_index_get"
-        parameters:
-          - $ref: "#/parameters/index"
-        responses:
-          200:
-            description: ""
-      post:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for multi search.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-        operationId: "elastic_msearch_index_post"
-        parameters:
-          - $ref: "#/parameters/index"
-        responses:
-          200:
-            description: ""
+  /{index}/_msearch:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for multi search.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+      operationId: "elastic_msearch_index_get"
+      parameters:
+        - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for multi search.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+      operationId: "elastic_msearch_index_post"
+      parameters:
+        - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
 
-    /{index}/_doc/{docId}:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for retrieving a single document.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
-        operationId: "elastic_doc_get"
-        parameters:
-          - $ref: "#/parameters/index"
-          - $ref: "#/parameters/docId"
-        responses:
-          200:
-            description: ""
+  /{index}/_doc/{docId}:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for retrieving a single document.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
+      operationId: "elastic_doc_get"
+      parameters:
+        - $ref: "#/parameters/index"
+        - $ref: "#/parameters/docId"
+      responses:
+        200:
+          description: ""
 
-    /{index}/_source/{docId}:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for retrieving a single document source.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
-        operationId: "elastic_source_get"
-        parameters:
-          - $ref: "#/parameters/index"
-          - $ref: "#/parameters/docId"
-        responses:
-          200:
-            description: ""
+  /{index}/_source/{docId}:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for retrieving a single document source.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
+      operationId: "elastic_source_get"
+      parameters:
+        - $ref: "#/parameters/index"
+        - $ref: "#/parameters/docId"
+      responses:
+        200:
+          description: ""
 
-  parameters:
-    index:
-      name: "index"
-      in: "path"
-      description: "The Elasticsearch index to search in. For all indices use _all"
-      required: true
-      type: "string"
-    docId:
-      name: "docId"
-      in: "path"
-      description: "The numeric document ID to be selected"
-      required: true
-      type: "string"
+parameters:
+  index:
+    name: "index"
+    in: "path"
+    description: "The Elasticsearch index to search in. For all indices use _all"
+    required: true
+    type: "string"
+  docId:
+    name: "docId"
+    in: "path"
+    description: "The numeric document ID to be selected"
+    required: true
+    type: "string"

--- a/deployment/endpoints/production.yaml
+++ b/deployment/endpoints/production.yaml
@@ -41,41 +41,55 @@ paths:
         200:
           description: ""
 
-  /_cat/health:
-    get:
-      tags:
-      - "Elasticsearch API"
-      description: |
-        Health is a terse, one-line representation of the same information from /_cluster/health.
-        See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-health.html for more information.
-      operationId: "elastic_health_get"
-      responses:
-        200:
-          description: ""
+    /_cat/indices/{index}:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint displaying the indices that match the index filter.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html for more information.
+        operationId: "elastic_indices_get_index"
+        parameters:
+          - $ref: "#/parameters/index"
+        responses:
+          200:
+            description: ""
 
-  /_search:
-    get:
-      tags:
-      - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for searching.
-        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-      operationId: "elastic_search_get"
-      responses:
-        200:
-          description: ""
-    post:
-      tags:
-      - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for searching.
-        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-      operationId: "elastic_search_post"
-      responses:
-        200:
-          description: ""
+    /_cat/health:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Health is a terse, one-line representation of the same information from /_cluster/health.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-health.html for more information.
+        operationId: "elastic_health_get"
+        responses:
+          200:
+            description: ""
 
-  /_msearch:
+    /_search:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for searching.
+          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+        operationId: "elastic_search_get"
+        responses:
+          200:
+            description: ""
+      post:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for searching.
+          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+        operationId: "elastic_search_post"
+        responses:
+          200:
+            description: ""
+
+    /_msearch:
       get:
         tags:
           - "Elasticsearch API"
@@ -97,62 +111,98 @@ paths:
           200:
             description: ""
 
-  /{index}/_search:
-    get:
-      tags:
-        - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for searching.
-        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-      operationId: "elastic_search_index_get"
-      parameters:
-        - $ref: "#/parameters/index"
-      responses:
-        200:
-          description: ""
-    post:
-      tags:
-       - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for searching.
-        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-      operationId: "elastic_search_index_post"
-      parameters:
-        - $ref: "#/parameters/index"
-      responses:
-        200:
-          description: ""
+    /{index}/_search:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for searching.
+          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+        operationId: "elastic_search_index_get"
+        parameters:
+          - $ref: "#/parameters/index"
+        responses:
+          200:
+            description: ""
+      post:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for searching.
+          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+        operationId: "elastic_search_index_post"
+        parameters:
+          - $ref: "#/parameters/index"
+        responses:
+          200:
+            description: ""
 
-  /{index}/_msearch:
-    get:
-      tags:
-        - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for multi search.
-        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-      operationId: "elastic_msearch_index_get"
-      parameters:
-        - $ref: "#/parameters/index"
-      responses:
-        200:
-          description: ""
-    post:
-      tags:
-        - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for multi search.
-        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-      operationId: "elastic_msearch_index_post"
-      parameters:
-        - $ref: "#/parameters/index"
-      responses:
-        200:
-          description: ""
+    /{index}/_msearch:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for multi search.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+        operationId: "elastic_msearch_index_get"
+        parameters:
+          - $ref: "#/parameters/index"
+        responses:
+          200:
+            description: ""
+      post:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for multi search.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+        operationId: "elastic_msearch_index_post"
+        parameters:
+          - $ref: "#/parameters/index"
+        responses:
+          200:
+            description: ""
 
-parameters:
-  index:
-    name: "index"
-    in: "path"
-    description: "The Elasticsearch index to search in. For all indices use _all"
-    required: true
-    type: "string"
+    /{index}/_doc/{docId}:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for retrieving a single document.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
+        operationId: "elastic_doc_get"
+        parameters:
+          - $ref: "#/parameters/index"
+          - $ref: "#/parameters/docId"
+        responses:
+          200:
+            description: ""
+
+    /{index}/_source/{docId}:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for retrieving a single document source.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
+        operationId: "elastic_source_get"
+        parameters:
+          - $ref: "#/parameters/index"
+          - $ref: "#/parameters/docId"
+        responses:
+          200:
+            description: ""
+
+  parameters:
+    index:
+      name: "index"
+      in: "path"
+      description: "The Elasticsearch index to search in. For all indices use _all"
+      required: true
+      type: "string"
+    docId:
+      name: "docId"
+      in: "path"
+      description: "The numeric document ID to be selected"
+      required: true
+      type: "string"

--- a/deployment/endpoints/staging.yaml
+++ b/deployment/endpoints/staging.yaml
@@ -41,168 +41,168 @@ paths:
         200:
           description: ""
 
-    /_cat/indices/{index}:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint displaying the indices that match the index filter.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html for more information.
-        operationId: "elastic_indices_get_index"
-        parameters:
-          - $ref: "#/parameters/index"
-        responses:
-          200:
-            description: ""
+  /_cat/indices/{index}:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint displaying the indices that match the index filter.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html for more information.
+      operationId: "elastic_indices_get_index"
+      parameters:
+        - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
 
-    /_cat/health:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Health is a terse, one-line representation of the same information from /_cluster/health.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-health.html for more information.
-        operationId: "elastic_health_get"
-        responses:
-          200:
-            description: ""
+  /_cat/health:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Health is a terse, one-line representation of the same information from /_cluster/health.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-health.html for more information.
+      operationId: "elastic_health_get"
+      responses:
+        200:
+          description: ""
 
-    /_search:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for searching.
-          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-        operationId: "elastic_search_get"
-        responses:
-          200:
-            description: ""
-      post:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for searching.
-          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-        operationId: "elastic_search_post"
-        responses:
-          200:
-            description: ""
+  /_search:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for searching.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+      operationId: "elastic_search_get"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for searching.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+      operationId: "elastic_search_post"
+      responses:
+        200:
+          description: ""
 
-    /_msearch:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for multi search.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-        operationId: "elastic_msearch_get"
-        responses:
-          200:
-            description: ""
-      post:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for multi search.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-        operationId: "elastic_msearch_post"
-        responses:
-          200:
-            description: ""
+  /_msearch:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for multi search.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+      operationId: "elastic_msearch_get"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for multi search.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+      operationId: "elastic_msearch_post"
+      responses:
+        200:
+          description: ""
 
-    /{index}/_search:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for searching.
-          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-        operationId: "elastic_search_index_get"
-        parameters:
-          - $ref: "#/parameters/index"
-        responses:
-          200:
-            description: ""
-      post:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for searching.
-          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-        operationId: "elastic_search_index_post"
-        parameters:
-          - $ref: "#/parameters/index"
-        responses:
-          200:
-            description: ""
+  /{index}/_search:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for searching.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+      operationId: "elastic_search_index_get"
+      parameters:
+        - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for searching.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+      operationId: "elastic_search_index_post"
+      parameters:
+        - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
 
-    /{index}/_msearch:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for multi search.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-        operationId: "elastic_msearch_index_get"
-        parameters:
-          - $ref: "#/parameters/index"
-        responses:
-          200:
-            description: ""
-      post:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for multi search.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-        operationId: "elastic_msearch_index_post"
-        parameters:
-          - $ref: "#/parameters/index"
-        responses:
-          200:
-            description: ""
+  /{index}/_msearch:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for multi search.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+      operationId: "elastic_msearch_index_get"
+      parameters:
+        - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for multi search.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+      operationId: "elastic_msearch_index_post"
+      parameters:
+        - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
 
-    /{index}/_doc/{docId}:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for retrieving a single document.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
-        operationId: "elastic_doc_get"
-        parameters:
-          - $ref: "#/parameters/index"
-          - $ref: "#/parameters/docId"
-        responses:
-          200:
-            description: ""
+  /{index}/_doc/{docId}:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for retrieving a single document.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
+      operationId: "elastic_doc_get"
+      parameters:
+        - $ref: "#/parameters/index"
+        - $ref: "#/parameters/docId"
+      responses:
+        200:
+          description: ""
 
-    /{index}/_source/{docId}:
-      get:
-        tags:
-          - "Elasticsearch API"
-        description: |
-          Elasticsearch endpoint for retrieving a single document source.
-          See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
-        operationId: "elastic_source_get"
-        parameters:
-          - $ref: "#/parameters/index"
-          - $ref: "#/parameters/docId"
-        responses:
-          200:
-            description: ""
+  /{index}/_source/{docId}:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for retrieving a single document source.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
+      operationId: "elastic_source_get"
+      parameters:
+        - $ref: "#/parameters/index"
+        - $ref: "#/parameters/docId"
+      responses:
+        200:
+          description: ""
 
-  parameters:
-    index:
-      name: "index"
-      in: "path"
-      description: "The Elasticsearch index to search in. For all indices use _all"
-      required: true
-      type: "string"
-    docId:
-      name: "docId"
-      in: "path"
-      description: "The numeric document ID to be selected"
-      required: true
-      type: "string"
+parameters:
+  index:
+    name: "index"
+    in: "path"
+    description: "The Elasticsearch index to search in. For all indices use _all"
+    required: true
+    type: "string"
+  docId:
+    name: "docId"
+    in: "path"
+    description: "The numeric document ID to be selected"
+    required: true
+    type: "string"

--- a/deployment/endpoints/staging.yaml
+++ b/deployment/endpoints/staging.yaml
@@ -41,41 +41,55 @@ paths:
         200:
           description: ""
 
-  /_cat/health:
-    get:
-      tags:
-      - "Elasticsearch API"
-      description: |
-        Health is a terse, one-line representation of the same information from /_cluster/health.
-        See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-health.html for more information.
-      operationId: "elastic_health_get"
-      responses:
-        200:
-          description: ""
+    /_cat/indices/{index}:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint displaying the indices that match the index filter.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html for more information.
+        operationId: "elastic_indices_get_index"
+        parameters:
+          - $ref: "#/parameters/index"
+        responses:
+          200:
+            description: ""
 
-  /_search:
-    get:
-      tags:
-      - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for searching.
-        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-      operationId: "elastic_search_get"
-      responses:
-        200:
-          description: ""
-    post:
-      tags:
-      - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for searching.
-        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-      operationId: "elastic_search_post"
-      responses:
-        200:
-          description: ""
+    /_cat/health:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Health is a terse, one-line representation of the same information from /_cluster/health.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-health.html for more information.
+        operationId: "elastic_health_get"
+        responses:
+          200:
+            description: ""
 
-  /_msearch:
+    /_search:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for searching.
+          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+        operationId: "elastic_search_get"
+        responses:
+          200:
+            description: ""
+      post:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for searching.
+          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+        operationId: "elastic_search_post"
+        responses:
+          200:
+            description: ""
+
+    /_msearch:
       get:
         tags:
           - "Elasticsearch API"
@@ -97,62 +111,98 @@ paths:
           200:
             description: ""
 
-  /{index}/_search:
-    get:
-      tags:
-        - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for searching.
-        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-      operationId: "elastic_search_index_get"
-      parameters:
-        - $ref: "#/parameters/index"
-      responses:
-        200:
-          description: ""
-    post:
-      tags:
-       - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for searching.
-        See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
-      operationId: "elastic_search_index_post"
-      parameters:
-        - $ref: "#/parameters/index"
-      responses:
-        200:
-          description: ""
+    /{index}/_search:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for searching.
+          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+        operationId: "elastic_search_index_get"
+        parameters:
+          - $ref: "#/parameters/index"
+        responses:
+          200:
+            description: ""
+      post:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for searching.
+          See https://elastic.co/guide/en/elasticsearch/reference/current/search-search.html for more information.
+        operationId: "elastic_search_index_post"
+        parameters:
+          - $ref: "#/parameters/index"
+        responses:
+          200:
+            description: ""
 
-  /{index}/_msearch:
-    get:
-      tags:
-        - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for multi search.
-        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-      operationId: "elastic_msearch_index_get"
-      parameters:
-        - $ref: "#/parameters/index"
-      responses:
-        200:
-          description: ""
-    post:
-      tags:
-        - "Elasticsearch API"
-      description: |
-        Elasticsearch endpoint for multi search.
-        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
-      operationId: "elastic_msearch_index_post"
-      parameters:
-        - $ref: "#/parameters/index"
-      responses:
-        200:
-          description: ""
+    /{index}/_msearch:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for multi search.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+        operationId: "elastic_msearch_index_get"
+        parameters:
+          - $ref: "#/parameters/index"
+        responses:
+          200:
+            description: ""
+      post:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for multi search.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for more information.
+        operationId: "elastic_msearch_index_post"
+        parameters:
+          - $ref: "#/parameters/index"
+        responses:
+          200:
+            description: ""
 
-parameters:
-  index:
-    name: "index"
-    in: "path"
-    description: "The Elasticsearch index to search in. For all indices use _all"
-    required: true
-    type: "string"
+    /{index}/_doc/{docId}:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for retrieving a single document.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
+        operationId: "elastic_doc_get"
+        parameters:
+          - $ref: "#/parameters/index"
+          - $ref: "#/parameters/docId"
+        responses:
+          200:
+            description: ""
+
+    /{index}/_source/{docId}:
+      get:
+        tags:
+          - "Elasticsearch API"
+        description: |
+          Elasticsearch endpoint for retrieving a single document source.
+          See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html for more information.
+        operationId: "elastic_source_get"
+        parameters:
+          - $ref: "#/parameters/index"
+          - $ref: "#/parameters/docId"
+        responses:
+          200:
+            description: ""
+
+  parameters:
+    index:
+      name: "index"
+      in: "path"
+      description: "The Elasticsearch index to search in. For all indices use _all"
+      required: true
+      type: "string"
+    docId:
+      name: "docId"
+      in: "path"
+      description: "The numeric document ID to be selected"
+      required: true
+      type: "string"

--- a/ocd_backend/enrichers/media_enricher/__init__.py
+++ b/ocd_backend/enrichers/media_enricher/__init__.py
@@ -6,7 +6,7 @@ from ocd_backend.enrichers.media_enricher.tasks.ggm import \
     GegevensmagazijnMotionText
 from ocd_backend.exceptions import UnsupportedContentType
 from ocd_backend.log import get_source_logger
-from ocd_backend.settings import RESOLVER_BASE_URL
+from ocd_backend.settings import RESOLVER_BASE_URL, AUTORETRY_EXCEPTIONS
 from ocd_backend.utils.http import HttpRequestMixin
 
 log = get_source_logger('enricher')
@@ -83,6 +83,6 @@ class MediaEnricher(BaseEnricher, HttpRequestMixin):
         item.save()
 
 
-@celery_app.task(bind=True, base=MediaEnricher, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=MediaEnricher, autoretry_for=AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def media_enricher(self, *args, **kwargs):
     return self.start(*args, **kwargs)

--- a/ocd_backend/enrichers/media_enricher/static.py
+++ b/ocd_backend/enrichers/media_enricher/static.py
@@ -1,4 +1,4 @@
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.enrichers.media_enricher import MediaEnricher
 from ocd_backend.log import get_source_logger
 from ocd_backend.utils.http import HttpRequestMixin, LocalCachingMixin, GCSCachingMixin
@@ -18,16 +18,16 @@ class GCSStaticMediaEnricher(MediaEnricher, GCSCachingMixin):
     bucket_name = 'ori-static'
 
 
-@celery_app.task(bind=True, base=TemporaryFileMediaEnricher, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=TemporaryFileMediaEnricher, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def temporary_file_media_enricher(self, *args, **kwargs):
     return self.start(*args, **kwargs)
 
 
-@celery_app.task(bind=True, base=LocalStaticMediaEnricher, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=LocalStaticMediaEnricher, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def local_static_media_enricher(self, *args, **kwargs):
     return self.start(*args, **kwargs)
 
 
-@celery_app.task(bind=True, base=GCSStaticMediaEnricher, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=GCSStaticMediaEnricher, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def gcs_static_media_enricher(self, *args, **kwargs):
     return self.start(*args, **kwargs)

--- a/ocd_backend/loaders/delta.py
+++ b/ocd_backend/loaders/delta.py
@@ -66,6 +66,6 @@ def delivery_report(err, msg):
         log.debug('Message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
 
 
-@celery_app.task(bind=True, base=DeltaLoader, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=DeltaLoader, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def delta_loader(self, *args, **kwargs):
     return self.start(*args, **kwargs)

--- a/ocd_backend/loaders/elasticsearch.py
+++ b/ocd_backend/loaders/elasticsearch.py
@@ -121,16 +121,16 @@ class ElasticsearchUpsertLoader(ElasticsearchLoader):
                                     body=url_doc)
 
 
-@celery_app.task(bind=True, base=ElasticsearchLoader, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=ElasticsearchLoader, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def elasticsearch_loader(self, *args, **kwargs):
     return self.start(*args, **kwargs)
 
 
-@celery_app.task(bind=True, base=ElasticsearchUpdateOnlyLoader, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=ElasticsearchUpdateOnlyLoader, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def elasticsearch_update_only_loader(self, *args, **kwargs):
     return self.start(*args, **kwargs)
 
 
-@celery_app.task(bind=True, base=ElasticsearchUpsertLoader, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=ElasticsearchUpsertLoader, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def elasticsearch_upsert_loader(self, *args, **kwargs):
     return self.start(*args, **kwargs)

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 from copy import deepcopy
 from datetime import datetime
 from uuid import uuid4
@@ -24,6 +26,13 @@ def setup_pipeline(source_definition):
         index_name=source_definition.get('index_name',
                                          source_definition.get('id'))
     )
+
+    # Purge and recreate temp dir to prevent No space left on device, see #236
+    try:
+        shutil.rmtree(settings.TEMP_DIR_PATH, ignore_errors=True)
+        os.mkdir(settings.TEMP_DIR_PATH)
+    except OSError:
+        pass
 
     if not es.indices.exists(index_alias):
         index_name = '{index_alias}_{now}'.format(index_alias=index_alias,

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -16,7 +16,7 @@ from ocd_backend.utils.misc import load_object, propagate_chain_get
 logger = get_source_logger('pipeline')
 
 
-@celery_app.task(autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def setup_pipeline(source_definition):
     logger.debug('[%s] Starting pipeline for source: %s' % (source_definition['key'], source_definition.get('id')))
 

--- a/ocd_backend/requirements.txt
+++ b/ocd_backend/requirements.txt
@@ -20,9 +20,9 @@ python-magic==0.4.13
 pyyaml==4.2b1
 rdflib==4.2.2
 requests==2.20.0
-suds-community==0.8.3
 sqlalchemy==1.3.4
 sqlalchemy-utils==0.34.0
 urllib3==1.24.2
 tika==1.13.1
 translitcodec==0.4.0
+zeep==3.4.0

--- a/ocd_backend/requirements.txt
+++ b/ocd_backend/requirements.txt
@@ -10,7 +10,7 @@ google-cloud-storage==1.11.0
 iso8601==0.1.10
 lxml==4.3.3
 msgpack-python==0.4.2
--e git+https://github.com/izderadicka/pdfparser#egg=pdfparser
+pdftotext==2.1.2
 Pillow==5.2.0
 psycopg2==2.8.3
 PyLD==1.0.5
@@ -23,6 +23,5 @@ requests==2.20.0
 sqlalchemy==1.3.4
 sqlalchemy-utils==0.34.0
 urllib3==1.24.2
-tika==1.13.1
 translitcodec==0.4.0
 zeep==3.4.0

--- a/ocd_backend/settings.py
+++ b/ocd_backend/settings.py
@@ -301,6 +301,9 @@ CWC_WSDL = u'https://services.companywebcast.com/meta/1.2/metaservice.svc?single
 PDF_TO_TEXT = u'pdftotext'
 PDF_MAX_MEDIABOX_PIXELS = 5000000
 
+# Exceptions that when raised should be autoretried by celery
+AUTORETRY_EXCEPTIONS = []
+
 # Kafka settings for DeltaLoader
 KAFKA_ENABLED = os.getenv('KAFKA_ENABLED', True)
 KAFKA_HOST = os.getenv('KAFKA_HOST', 'localhost:9092')

--- a/ocd_backend/settings.py
+++ b/ocd_backend/settings.py
@@ -292,7 +292,7 @@ RESOLVER_URL_INDEX = 'resolver'
 USER_AGENT = 'Open Raadsinformatie/%s.%s (+http://www.openraadsinformatie.nl/)' % (MAJOR_VERSION, MINOR_VERSION)
 
 # The endpoint for the iBabs API
-IBABS_WSDL = u'https://www.mijnbabs.nl/iBabsWCFService/Public.svc?singleWsdl'
+IBABS_WSDL = u'https://wcf.ibabs.eu/api/Public.svc?singleWsdl'
 
 # The endpoint for the CompanyWebcast API
 CWC_WSDL = u'https://services.companywebcast.com/meta/1.2/metaservice.svc?singleWsdl'

--- a/ocd_backend/tasks.py
+++ b/ocd_backend/tasks.py
@@ -76,11 +76,11 @@ class DummyCleanup(BaseCleanup):
         log.info('Finished run {}.'.format(run_identifier))
 
 
-@celery_app.task(bind=True, base=CleanupElasticsearch, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=CleanupElasticsearch, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def cleanup_elasticsearch(self, *args, **kwargs):
     return self.start(*args, **kwargs)
 
 
-@celery_app.task(bind=True, base=DummyCleanup, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=DummyCleanup, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def dummy_cleanup(self, *args, **kwargs):
     return self.start(*args, **kwargs)

--- a/ocd_backend/transformers/goapi_committee.py
+++ b/ocd_backend/transformers/goapi_committee.py
@@ -1,4 +1,4 @@
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -6,7 +6,7 @@ from ocd_backend.log import get_source_logger
 log = get_source_logger('goapi_committee')
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def committee_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/goapi_meeting.py
+++ b/ocd_backend/transformers/goapi_meeting.py
@@ -1,6 +1,6 @@
 import iso8601
 
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -30,7 +30,7 @@ class GOAPITransformer(BaseTransformer):
 
 
 # noinspection DuplicatedCode
-@celery_app.task(bind=True, base=GOAPITransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=GOAPITransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def meeting_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/gv.py
+++ b/ocd_backend/transformers/gv.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from hashlib import sha1
 
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -79,7 +79,7 @@ class GreenValleyTransformer(BaseTransformer):
             return []
         
 
-@celery_app.task(bind=True, base=GreenValleyTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=GreenValleyTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def greenvalley_report(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']
@@ -172,7 +172,7 @@ def greenvalley_report(self, content_type, raw_item, entity, source_item, **kwar
     return event
 
 
-@celery_app.task(bind=True, base=GreenValleyTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=GreenValleyTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def meeting_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/ibabs_committee.py
+++ b/ocd_backend/transformers/ibabs_committee.py
@@ -1,4 +1,4 @@
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -6,7 +6,7 @@ from ocd_backend.log import get_source_logger
 log = get_source_logger('ibabs_committee')
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def committee_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/ibabs_meeting.py
+++ b/ocd_backend/transformers/ibabs_meeting.py
@@ -2,7 +2,7 @@ import re
 
 import iso8601
 
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -10,7 +10,7 @@ from ocd_backend.log import get_source_logger
 log = get_source_logger('ibabs_meeting')
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def meeting_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/ibabs_person.py
+++ b/ocd_backend/transformers/ibabs_person.py
@@ -1,4 +1,4 @@
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -6,7 +6,7 @@ from ocd_backend.log import get_source_logger
 log = get_source_logger('ibabs_person')
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def person_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/ibabs_report.py
+++ b/ocd_backend/transformers/ibabs_report.py
@@ -2,7 +2,7 @@ import re
 
 import iso8601
 
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -10,7 +10,7 @@ from ocd_backend.log import get_source_logger
 log = get_source_logger('ibabs_report')
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def report_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/notubiz_committee.py
+++ b/ocd_backend/transformers/notubiz_committee.py
@@ -1,4 +1,4 @@
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -6,7 +6,7 @@ from ocd_backend.log import get_source_logger
 log = get_source_logger('notubiz_committee')
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def committee_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/notubiz_meeting.py
+++ b/ocd_backend/transformers/notubiz_meeting.py
@@ -1,4 +1,4 @@
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -6,7 +6,7 @@ from ocd_backend.log import get_source_logger
 log = get_source_logger('notubiz_meeting')
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def meeting_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/organizations.py
+++ b/ocd_backend/transformers/organizations.py
@@ -1,4 +1,4 @@
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -22,7 +22,7 @@ def transform_contact_details(data):
     return transformed_data
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def municipality_organization_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']
@@ -47,7 +47,7 @@ def municipality_organization_item(self, content_type, raw_item, entity, source_
     return object_model
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def province_organization_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']
@@ -72,7 +72,7 @@ def province_organization_item(self, content_type, raw_item, entity, source_item
     return object_model
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def party_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/persons.py
+++ b/ocd_backend/transformers/persons.py
@@ -1,4 +1,4 @@
-from ocd_backend import celery_app
+from ocd_backend import celery_app, settings
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.models import *
 from ocd_backend.log import get_source_logger
@@ -6,7 +6,7 @@ from ocd_backend.log import get_source_logger
 log = get_source_logger('persons')
 
 
-@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=(Exception,), retry_backoff=True)
+@celery_app.task(bind=True, base=BaseTransformer, autoretry_for=settings.AUTORETRY_EXCEPTIONS, retry_backoff=True)
 def allmanak_person_item(self, content_type, raw_item, entity, source_item, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/utils/ibabs.py
+++ b/ocd_backend/utils/ibabs.py
@@ -135,18 +135,6 @@ def meeting_item_to_dict(m):
     return _ibabs_to_dict(m, fields)
 
 
-def meeting_type_to_dict(mt):
-    """
-    Converts an iBabsMeetingType to a JSON serializable dict
-    """
-    fields = {
-        'Id': None,
-        'Meetingtype': None,
-        'Abbreviation': None,
-    }
-    return _ibabs_to_dict(mt, fields)
-
-
 def _list_response_field_to_val(r):
     if isinstance(r, list):
         return [unicode(l) for l in r]
@@ -178,10 +166,3 @@ def list_entry_response_to_dict(m):
             unicode(y.Key): unicode(y.Value) if y.Value is not None else None for y in x[0]}
     }
     return _ibabs_to_dict(m, fields)
-
-
-def person_profile_to_dict(p):
-    """
-    Converts an iBabsListEntryBasic to a JSON serializable dict
-    """
-    return {k[0]: _list_response_field_to_val(k[1]) for k in p}


### PR DESCRIPTION
I'd like to use some (safe) ES endpoints that haven't been enabled yet.

To start, I've added:
- `GET /_cat/indices/{index}`
- `GET /{index}/_doc/{docId}`
- `GET /{index}/_source/{docId}`

Maintainers can edit this feature branch, so feel free to fix any mistakes you might find.
