### PR TITLE
Additional scroll and mapping Google Endpoints

### DIFF
--- a/deployment/endpoints/production.yaml
+++ b/deployment/endpoints/production.yaml
@@ -89,7 +89,7 @@ paths:
         200:
           description: ""
 
-  /_search/scroll/{scrollId}:
+  /_search/scroll:
     get:
       tags:
         - "Elasticsearch API"
@@ -98,7 +98,7 @@ paths:
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
       operationId: "elastic_search_scroll_get"
       parameters:
-      - $ref: "#/parameters/scrollId"
+      - $ref: "#/parameters/scroll_id"
       responses:
         200:
           description: ""
@@ -110,7 +110,7 @@ paths:
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
       operationId: "elastic_search_scroll_post"
       parameters:
-      - $ref: "#/parameters/scrollId"
+      - $ref: "#/parameters/scroll_id"
       responses:
         200:
           description: ""
@@ -121,6 +121,44 @@ paths:
         Elasticsearch endpoint to clear a scroll search context.
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#_clear_scroll_api for more information.
       operationId: "elastic_search_scroll_delete"
+      parameters:
+      - $ref: "#/parameters/scroll_id"
+      responses:
+        200:
+          description: ""
+
+  /_search/scroll/{scrollId}:
+    get:
+      tags:
+      - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for scrolled searches.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
+      operationId: "elastic_search_scrollId_get"
+      parameters:
+      - $ref: "#/parameters/scrollId"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+      - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for scrolled searches.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
+      operationId: "elastic_search_scrollId_post"
+      parameters:
+      - $ref: "#/parameters/scrollId"
+      responses:
+        200:
+          description: ""
+    delete:
+      tags:
+      - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint to clear a scroll search context.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#_clear_scroll_api for more information.
+      operationId: "elastic_search_scrollId_delete"
       parameters:
       - $ref: "#/parameters/scrollId"
       responses:
@@ -249,4 +287,10 @@ parameters:
     in: "path"
     description: "The base64-encoded scroll ID to fetch the next batch of results from"
     required: true
+    type: "string"
+  scroll_id:
+    name: "scroll_id"
+    in: "query"
+    description: "The base64-encoded scroll ID to fetch the next batch of results from"
+    required: false
     type: "string"

--- a/deployment/endpoints/production.yaml
+++ b/deployment/endpoints/production.yaml
@@ -269,6 +269,32 @@ paths:
         200:
           description: ""
 
+  /_mapping:
+    get:
+      tags:
+      - "Elasticsearch API"
+      description: |
+        Retrieves mapping definitions for indices in a cluster.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html for more information.
+      operationId: "elastic_mapping_get"
+      responses:
+        200:
+          description: ""
+
+  /{index}/_mapping:
+    get:
+      tags:
+      - "Elasticsearch API"
+      description: |
+        Retrieves mapping definitions for indices in a cluster.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html for more information.
+      operationId: "elastic_mapping_index_get"
+      parameters:
+      - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
+
 parameters:
   index:
     name: "index"

--- a/deployment/endpoints/production.yaml
+++ b/deployment/endpoints/production.yaml
@@ -97,6 +97,8 @@ paths:
         Elasticsearch endpoint for scrolled searches.
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
       operationId: "elastic_search_scroll_get"
+      parameters:
+      - $ref: "#/parameters/scrollId"
       responses:
         200:
           description: ""
@@ -107,6 +109,8 @@ paths:
         Elasticsearch endpoint for scrolled searches.
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
       operationId: "elastic_search_scroll_post"
+      parameters:
+      - $ref: "#/parameters/scrollId"
       responses:
         200:
           description: ""
@@ -117,6 +121,8 @@ paths:
         Elasticsearch endpoint to clear a scroll search context.
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#_clear_scroll_api for more information.
       operationId: "elastic_search_scroll_delete"
+      parameters:
+      - $ref: "#/parameters/scrollId"
       responses:
         200:
           description: ""
@@ -242,5 +248,5 @@ parameters:
     name: "scrollId"
     in: "path"
     description: "The base64-encoded scroll ID to fetch the next batch of results from"
-    required: false
+    required: true
     type: "string"

--- a/deployment/endpoints/production.yaml
+++ b/deployment/endpoints/production.yaml
@@ -89,6 +89,38 @@ paths:
         200:
           description: ""
 
+  /_search/scroll/{scrollId}:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for scrolled searches.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
+      operationId: "elastic_search_scroll_get"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for scrolled searches.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
+      operationId: "elastic_search_scroll_post"
+      responses:
+        200:
+          description: ""
+    delete:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint to clear a scroll search context.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#_clear_scroll_api for more information.
+      operationId: "elastic_search_scroll_delete"
+      responses:
+        200:
+          description: ""
+
   /_msearch:
     get:
       tags:
@@ -205,4 +237,10 @@ parameters:
     in: "path"
     description: "The numeric document ID to be selected"
     required: true
+    type: "string"
+  scrollId:
+    name: "scrollId"
+    in: "path"
+    description: "The base64-encoded scroll ID to fetch the next batch of results from"
+    required: false
     type: "string"

--- a/deployment/endpoints/staging.yaml
+++ b/deployment/endpoints/staging.yaml
@@ -89,14 +89,52 @@ paths:
         200:
           description: ""
 
-  /_search/scroll/{scrollId}:
+  /_search/scroll:
     get:
       tags:
-        - "Elasticsearch API"
+      - "Elasticsearch API"
       description: |
         Elasticsearch endpoint for scrolled searches.
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
       operationId: "elastic_search_scroll_get"
+      parameters:
+      - $ref: "#/parameters/scroll_id"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+      - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for scrolled searches.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
+      operationId: "elastic_search_scroll_post"
+      parameters:
+      - $ref: "#/parameters/scroll_id"
+      responses:
+        200:
+          description: ""
+    delete:
+      tags:
+      - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint to clear a scroll search context.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#_clear_scroll_api for more information.
+      operationId: "elastic_search_scroll_delete"
+      parameters:
+      - $ref: "#/parameters/scroll_id"
+      responses:
+        200:
+          description: ""
+
+  /_search/scroll/{scrollId}:
+    get:
+      tags:
+      - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for scrolled searches.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
+      operationId: "elastic_search_scrollId_get"
       parameters:
       - $ref: "#/parameters/scrollId"
       responses:
@@ -104,11 +142,11 @@ paths:
           description: ""
     post:
       tags:
-        - "Elasticsearch API"
+      - "Elasticsearch API"
       description: |
         Elasticsearch endpoint for scrolled searches.
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
-      operationId: "elastic_search_scroll_post"
+      operationId: "elastic_search_scrollId_post"
       parameters:
       - $ref: "#/parameters/scrollId"
       responses:
@@ -116,11 +154,11 @@ paths:
           description: ""
     delete:
       tags:
-        - "Elasticsearch API"
+      - "Elasticsearch API"
       description: |
         Elasticsearch endpoint to clear a scroll search context.
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#_clear_scroll_api for more information.
-      operationId: "elastic_search_scroll_delete"
+      operationId: "elastic_search_scrollId_delete"
       parameters:
       - $ref: "#/parameters/scrollId"
       responses:
@@ -249,4 +287,10 @@ parameters:
     in: "path"
     description: "The base64-encoded scroll ID to fetch the next batch of results from"
     required: true
+    type: "string"
+  scroll_id:
+    name: "scroll_id"
+    in: "query"
+    description: "The base64-encoded scroll ID to fetch the next batch of results from"
+    required: false
     type: "string"

--- a/deployment/endpoints/staging.yaml
+++ b/deployment/endpoints/staging.yaml
@@ -269,6 +269,32 @@ paths:
         200:
           description: ""
 
+  /_mapping:
+    get:
+      tags:
+      - "Elasticsearch API"
+      description: |
+        Retrieves mapping definitions for indices in a cluster.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html for more information.
+      operationId: "elastic_mapping_get"
+      responses:
+        200:
+          description: ""
+
+  /{index}/_mapping:
+    get:
+      tags:
+      - "Elasticsearch API"
+      description: |
+        Retrieves mapping definitions for indices in a cluster.
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html for more information.
+      operationId: "elastic_mapping_index_get"
+      parameters:
+      - $ref: "#/parameters/index"
+      responses:
+        200:
+          description: ""
+
 parameters:
   index:
     name: "index"

--- a/deployment/endpoints/staging.yaml
+++ b/deployment/endpoints/staging.yaml
@@ -97,6 +97,8 @@ paths:
         Elasticsearch endpoint for scrolled searches.
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
       operationId: "elastic_search_scroll_get"
+      parameters:
+      - $ref: "#/parameters/scrollId"
       responses:
         200:
           description: ""
@@ -107,6 +109,8 @@ paths:
         Elasticsearch endpoint for scrolled searches.
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
       operationId: "elastic_search_scroll_post"
+      parameters:
+      - $ref: "#/parameters/scrollId"
       responses:
         200:
           description: ""
@@ -117,6 +121,8 @@ paths:
         Elasticsearch endpoint to clear a scroll search context.
         See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#_clear_scroll_api for more information.
       operationId: "elastic_search_scroll_delete"
+      parameters:
+      - $ref: "#/parameters/scrollId"
       responses:
         200:
           description: ""
@@ -242,5 +248,5 @@ parameters:
     name: "scrollId"
     in: "path"
     description: "The base64-encoded scroll ID to fetch the next batch of results from"
-    required: false
+    required: true
     type: "string"

--- a/deployment/endpoints/staging.yaml
+++ b/deployment/endpoints/staging.yaml
@@ -89,6 +89,38 @@ paths:
         200:
           description: ""
 
+  /_search/scroll/{scrollId}:
+    get:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for scrolled searches.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
+      operationId: "elastic_search_scroll_get"
+      responses:
+        200:
+          description: ""
+    post:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint for scrolled searches.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html for more information.
+      operationId: "elastic_search_scroll_post"
+      responses:
+        200:
+          description: ""
+    delete:
+      tags:
+        - "Elasticsearch API"
+      description: |
+        Elasticsearch endpoint to clear a scroll search context.
+        See https://elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#_clear_scroll_api for more information.
+      operationId: "elastic_search_scroll_delete"
+      responses:
+        200:
+          description: ""
+
   /_msearch:
     get:
       tags:
@@ -205,4 +237,10 @@ parameters:
     in: "path"
     description: "The numeric document ID to be selected"
     required: true
+    type: "string"
+  scrollId:
+    name: "scrollId"
+    in: "path"
+    description: "The base64-encoded scroll ID to fetch the next batch of results from"
+    required: false
     type: "string"


### PR DESCRIPTION
Copied from #296:

By allowing requests to the scroll endpoint, API users can more efficiently fetch the full set of results for a query. Currently, the scroll query can be initialized, but any result batches beyond the first cannot be requested/downloaded.

The GET and POST methods on this endpoint are used to fetch subsequent result batches. The DELETE method is needed to clear the search context whenever the user abandons the scrolled search, or when the available results have been exhausted. Without this DELETE request, the search context will take up some ES heap until the scroll times out.