### PR TITLE
Optimizations for update_source

### DIFF
--- a/ocd_backend/transformers/gedeputeerdestaten.py
+++ b/ocd_backend/transformers/gedeputeerdestaten.py
@@ -83,7 +83,6 @@ def gs_meeting_item(self, content_type, raw_item, canonical_iri, cached_path, **
     details = self.deserialize_item('application/html', content)
 
     event = Meeting(original_id, **source_defaults)
-    event.canonical_id = original_id
     event.has_organization_name = province
 
     raw_datum_str = u''.join(


### PR DESCRIPTION
* Switched order of `update_source` scenarios to reduce unnecessary database reads;
* Improved `update_source` exception handling to give clearer error messages and make it not block the database save process;
* Removed a superfluous canonical_id assignment in `gedeputeerdestaten` transformer.