### PR TITLE
Send Kafka statements individually when the document is too large

### DIFF
--- a/ocd_backend/settings.py
+++ b/ocd_backend/settings.py
@@ -314,6 +314,7 @@ KAFKA_PASSWORD = os.getenv('KAFKA_PASSWORD')
 KAFKA_SESSION_TIMEOUT = os.getenv('KAFKA_SESSION_TIMEOUT', 5000)
 KAFKA_MESSAGE_KEY = os.getenv('KAFKA_MESSAGE_KEY', 'ori_delta_message')
 KAFKA_TOPIC = os.getenv('KAFKA_TOPIC', 'ori-delta')
+KAFKA_MAX_MESSAGE_BYTES = 8388608
 
 # Postgres settings
 POSTGRES_HOST = '{}:{}'.format(os.getenv('POSTGRES_SERVICE_HOST', 'postgres'), os.getenv('POSTGRES_SERVICE_PORT', 5432))


### PR DESCRIPTION
Send Kafka statements individually when the document exceeds the maximum number of bytes allowed to avoid documents that are too large not coming through to the API.