### PR TITLE
Fix retry mechanism

### DIFF
--- a/ocd_backend/enrichers/media_enricher/__init__.py
+++ b/ocd_backend/enrichers/media_enricher/__init__.py
@@ -5,7 +5,7 @@ from ocd_backend.app import celery_app
 from ocd_backend.enrichers import BaseEnricher
 from ocd_backend.exceptions import SkipEnrichment
 from ocd_backend.log import get_source_logger
-from ocd_backend.settings import RESOLVER_BASE_URL, AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import RESOLVER_BASE_URL, AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 from ocd_backend.utils.http import HttpRequestSimple
 from ocd_backend.utils.misc import strip_scheme
 from ocd_backend.enrichers.media_enricher.tasks.image_metadata import ImageMetadata
@@ -75,6 +75,6 @@ class MediaEnricher(BaseEnricher, HttpRequestSimple):
 
 
 @celery_app.task(bind=True, base=MediaEnricher, autoretry_for=AUTORETRY_EXCEPTIONS, 
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def media_enricher(self, *args, **kwargs):
     return self.start(*args, **kwargs)

--- a/ocd_backend/enrichers/text_enricher/__init__.py
+++ b/ocd_backend/enrichers/text_enricher/__init__.py
@@ -10,7 +10,7 @@ from ocd_backend.app import celery_app
 from ocd_backend.enrichers import BaseEnricher
 from ocd_backend.exceptions import SkipEnrichment
 from ocd_backend.log import get_source_logger
-from ocd_backend.settings import RESOLVER_BASE_URL, AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import RESOLVER_BASE_URL, RETRY_MAX_RETRIES
 from ocd_backend.utils.file_parsing import file_parser
 from ocd_backend.utils.http import HttpRequestSimple
 from ocd_backend.utils.misc import strip_scheme
@@ -18,6 +18,7 @@ from ocd_backend.utils.misc import strip_scheme
 from ocd_backend.enrichers.text_enricher.tasks.void import VoidEnrichtmentTask
 from ocd_backend.enrichers.text_enricher.tasks.theme_classifier import ThemeClassifier
 from ocd_backend.enrichers.text_enricher.tasks.waaroverheid import WaarOverheidEnricher
+from ocd_backend.utils.retry_utils import retry_task
 
 log = get_source_logger('enricher')
 
@@ -106,7 +107,7 @@ class TextEnricher(BaseEnricher):
         item.db.save(item)
 
 
-@celery_app.task(bind=True, base=TextEnricher, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+@celery_app.task(bind=True, base=TextEnricher, max_retries=RETRY_MAX_RETRIES)
+@retry_task
 def text_enricher(self, *args, **kwargs):
     return self.start(*args, **kwargs)

--- a/ocd_backend/loaders/elasticsearch.py
+++ b/ocd_backend/loaders/elasticsearch.py
@@ -8,7 +8,7 @@ from ocd_backend.loaders import BaseLoader
 from ocd_backend.log import get_source_logger
 from ocd_backend.models.serializers import JsonLDSerializer
 from ocd_backend.utils.misc import json_encoder
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('elasticsearch_loader')
 
@@ -81,18 +81,18 @@ class ElasticsearchUpsertLoader(ElasticsearchBaseLoader):
 
 
 @celery_app.task(bind=True, base=ElasticsearchLoader, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def elasticsearch_loader(self, *args, **kwargs):
     return self.start(*args, **kwargs)
 
 
 @celery_app.task(bind=True, base=ElasticsearchUpdateOnlyLoader, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def elasticsearch_update_only_loader(self, *args, **kwargs):
     return self.start(*args, **kwargs)
 
 
 @celery_app.task(bind=True, base=ElasticsearchUpsertLoader, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def elasticsearch_upsert_loader(self, *args, **kwargs):
     return self.start(*args, **kwargs)

--- a/ocd_backend/settings.py
+++ b/ocd_backend/settings.py
@@ -288,7 +288,7 @@ CWC_WSDL = 'https://services.companywebcast.com/meta/1.2/metaservice.svc?singleW
 # Exceptions that when raised should be autoretried by celery
 AUTORETRY_EXCEPTIONS = [MaxRetryError, ReadTimeoutError, ConnectTimeout, ConnectionError, exceptions.ConnectionError]
 AUTORETRY_RETRY_BACKOFF = 30
-AUTORETRY_MAX_RETRIES = 7
+RETRY_MAX_RETRIES = 7
 AUTORETRY_RETRY_BACKOFF_MAX = 3600
 
 # Postgres settings

--- a/ocd_backend/tasks.py
+++ b/ocd_backend/tasks.py
@@ -6,7 +6,7 @@ from ocd_backend.models.postgres_database import PostgresDatabase
 from ocd_backend.models.postgres_models import ItemHash
 from ocd_backend.models.serializers import PostgresSerializer
 from ocd_backend.utils.misc import iterate
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('ocd_backend.tasks')
 
@@ -116,17 +116,17 @@ class Finalizer(celery_app.Task):
 
 
 @celery_app.task(bind=True, base=CleanupElasticsearch, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def cleanup_elasticsearch(self, *args, **kwargs):
     return self.start(*args, **kwargs)
 
 
 @celery_app.task(bind=True, base=DummyCleanup, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def dummy_cleanup(self, *args, **kwargs):
     return self.start(*args, **kwargs)
 
 @celery_app.task(bind=True, base=Finalizer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def finalizer(self, *args, **kwargs):
     return self.start(*args, **kwargs)

--- a/ocd_backend/transformers/allmanak_organization.py
+++ b/ocd_backend/transformers/allmanak_organization.py
@@ -3,7 +3,7 @@ from ocd_backend.app import celery_app
 from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('organizations')
 
@@ -25,7 +25,7 @@ def transform_contact_details(data):
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def municipality_organization_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']
@@ -59,7 +59,7 @@ def municipality_organization_item(self, content_type, raw_item, canonical_iri, 
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def province_organization_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']
@@ -90,7 +90,7 @@ def province_organization_item(self, content_type, raw_item, canonical_iri, cach
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def party_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/allmanak_person.py
+++ b/ocd_backend/transformers/allmanak_person.py
@@ -3,13 +3,13 @@ from ocd_backend.app import celery_app
 from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('persons')
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def allmanak_person_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/database.py
+++ b/ocd_backend/transformers/database.py
@@ -8,7 +8,7 @@ from ocd_backend.transformers import BaseTransformer
 from ocd_backend.utils.misc import load_object
 from ocd_backend.models.model import PostgresDatabase
 from ocd_backend.models.serializers import PostgresSerializer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('database_transformer')
 
@@ -167,7 +167,7 @@ class DatabaseTransformer(BaseTransformer):
 
 
 @celery_app.task(bind=True, base=DatabaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def database_item(self, content_type, raw_item, entity, source_item, **kwargs):
     self.source_definition = kwargs['source_definition']
     resource, subresources = raw_item

--- a/ocd_backend/transformers/goapi_committee.py
+++ b/ocd_backend/transformers/goapi_committee.py
@@ -3,13 +3,13 @@ from ocd_backend.app import celery_app
 from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('goapi_committee')
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def committee_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/goapi_meeting.py
+++ b/ocd_backend/transformers/goapi_meeting.py
@@ -5,7 +5,7 @@ from ocd_backend.app import celery_app
 from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('goapi_meeting')
 
@@ -37,7 +37,7 @@ class GOAPITransformer(BaseTransformer):
 
 # noinspection DuplicatedCode
 @celery_app.task(bind=True, base=GOAPITransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def meeting_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/ibabs_committee.py
+++ b/ocd_backend/transformers/ibabs_committee.py
@@ -3,13 +3,13 @@ from ocd_backend.app import celery_app
 from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('ibabs_committee')
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def committee_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/ibabs_meeting.py
+++ b/ocd_backend/transformers/ibabs_meeting.py
@@ -6,13 +6,13 @@ from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.utils.ibabs import translate_position
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('ibabs_meeting')
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def meeting_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/ibabs_person.py
+++ b/ocd_backend/transformers/ibabs_person.py
@@ -6,13 +6,13 @@ from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.settings import RESOLVER_BASE_URL
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('ibabs_person')
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def person_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/ibabs_report.py
+++ b/ocd_backend/transformers/ibabs_report.py
@@ -79,8 +79,8 @@ def report_item(self, content_type, raw_item, canonical_iri, cached_path, **kwar
         report.description = original_item[description_field]
     except KeyError:
         try:
-            report.description = original_item['_Extra']['Values']['Omschrijving']
-        except KeyError:
+            report.description = original_item.get('_Extra', {}).get('Values', {}).get('Omschrijving')
+        except AttributeError:
             pass
 
     datum = original_item.get('datum')

--- a/ocd_backend/transformers/ibabs_report.py
+++ b/ocd_backend/transformers/ibabs_report.py
@@ -6,13 +6,13 @@ from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
 from ocd_backend.utils.misc import is_valid_iso8601_date
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('ibabs_report')
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def report_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/notubiz_committee.py
+++ b/ocd_backend/transformers/notubiz_committee.py
@@ -3,13 +3,13 @@ from ocd_backend.app import celery_app
 from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('notubiz_committee')
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def committee_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/notubiz_meeting.py
+++ b/ocd_backend/transformers/notubiz_meeting.py
@@ -3,13 +3,13 @@ from ocd_backend.app import celery_app
 from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('notubiz_meeting')
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def meeting_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/parlaeus_committee.py
+++ b/ocd_backend/transformers/parlaeus_committee.py
@@ -2,10 +2,10 @@ from ocd_backend import settings
 from ocd_backend.app import celery_app
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def committee_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/parlaeus_meeting.py
+++ b/ocd_backend/transformers/parlaeus_meeting.py
@@ -5,13 +5,13 @@ from ocd_backend import settings
 from ocd_backend.app import celery_app
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 from ocd_backend.log import get_source_logger
 
 log = get_source_logger('parlaeus_meeting')
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def meeting_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/transformers/parlaeus_person.py
+++ b/ocd_backend/transformers/parlaeus_person.py
@@ -3,13 +3,13 @@ from ocd_backend.app import celery_app
 from ocd_backend.log import get_source_logger
 from ocd_backend.models import *
 from ocd_backend.transformers import BaseTransformer
-from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, RETRY_MAX_RETRIES, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
 
 log = get_source_logger('ibabs_person')
 
 
 @celery_app.task(bind=True, base=BaseTransformer, autoretry_for=AUTORETRY_EXCEPTIONS,
-                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=AUTORETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
+                 retry_backoff=AUTORETRY_RETRY_BACKOFF, max_retries=RETRY_MAX_RETRIES, retry_backoff_max=AUTORETRY_RETRY_BACKOFF_MAX)
 def person_item(self, content_type, raw_item, canonical_iri, cached_path, **kwargs):
     original_item = self.deserialize_item(content_type, raw_item)
     self.source_definition = kwargs['source_definition']

--- a/ocd_backend/utils/http.py
+++ b/ocd_backend/utils/http.py
@@ -91,7 +91,7 @@ class HttpRequestMixin:
         # hacky solution to make the timeout for certain iBabs urls longer than for other
         # providers, as big files tend to have longer response times in iBabs
         if 'ibabs.eu' in url:
-            tm = 10
+            tm = 60
         else:
             tm = 5
         http_resp = self.http_session.get(url, stream=True, timeout=(3, tm), verify=False)

--- a/ocd_backend/utils/retry_utils.py
+++ b/ocd_backend/utils/retry_utils.py
@@ -1,0 +1,34 @@
+from celery.utils.time import get_exponential_backoff_interval
+from functools import wraps
+
+from ocd_backend.log import get_source_logger
+from ocd_backend.settings import AUTORETRY_EXCEPTIONS, AUTORETRY_RETRY_BACKOFF, AUTORETRY_RETRY_BACKOFF_MAX
+
+log = get_source_logger('retry_task')
+
+def retry_task(fun):
+    """
+    A decorator to use with celery tasks to retry tasks after an exception occurred.
+    When `autoretry_for` is used, all exceptions are reported to Sentry, also when they
+    are going to be retried. This is not desired - only when retrying the task a number of
+    times fails it should be reported.
+    The tasks that appeared in Sentry most often have been replaced by this decorator.
+    If there are more tasks that pollute Sentry, use this decorator and remove `autoretry_for`,
+    `retry_backoff` and `retry_backoff_max` from the @celery_app.task decorator.
+    """
+    @wraps(fun)
+    def handle_retry(self, *args, **kwargs):
+        try:
+            return fun(self, *args, **kwargs)
+        except tuple(AUTORETRY_EXCEPTIONS) as e:
+            try:
+                log.info(f'Retry attempt n = {self.request.retries} for error ({e.__class__.__name__}):\n{str(e)}')
+                countdown = get_exponential_backoff_interval(
+                    factor=AUTORETRY_RETRY_BACKOFF,
+                    retries=self.request.retries,
+                    maximum=AUTORETRY_RETRY_BACKOFF_MAX)
+                raise self.retry(countdown=countdown)
+            except self.MaxRetriesExceededError:
+                log.error(f'Maximum number of retries reached for error ({e.__class__.__name__}):\n{str(e)}')
+                raise
+    return handle_retry


### PR DESCRIPTION
Although Celery was already retrying failed tasks, the exceptions were still written to Sentry. This PR prevents exceptions being written to Sentry until after the last retry.