### PR TITLE
Deprecation notice: Classic API shuts down 1 November 2026

### DIFF
--- a/API-docs.md
+++ b/API-docs.md
@@ -1,5 +1,23 @@
 # OpenBesluitvorming / Open Raadsinformatie / Open Stateninformatie API docs
 
+> **⚠️ Deprecated — this API shuts down on 1 November 2026.**
+>
+> Open Raadsinformatie (ORI) Classic has been superseded by
+> [OpenBesluitvorming](https://openbesluitvorming.nl). This API is deprecated as of
+> 21 August 2026 and will be switched off on **1 November 2026**.
+>
+> - **Replacement:** https://openbesluitvorming.nl — search interface plus a
+>   documented REST API with bulk export and incremental synchronisation.
+> - **Migration guide:** https://openbesluitvorming.nl/docs/migration-guide
+> - **API reference:** https://openbesluitvorming.nl/docs/api
+> - **Blocked on something?** Open an issue on
+>   [ontola/openbesluitvorming](https://github.com/ontola/openbesluitvorming/issues),
+>   or mail sander.bakker@vng.nl.
+>
+> Until 1 November the existing endpoints keep working unchanged. After that date
+> this repository is archived and stays readable, and the data remains available
+> through OpenBesluitvorming.
+
 OpenBesluitvorming aims to make governmental decision making more transparent
 by aggregating and standardizing meeting & decision data.
 Currently, the API includes data from more than 300 municipalities and provinces.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # Open Raadsinformatie API
 
+> **⚠️ Deprecated — this API shuts down on 1 November 2026.**
+>
+> Open Raadsinformatie (ORI) Classic has been superseded by
+> [OpenBesluitvorming](https://openbesluitvorming.nl). This API is deprecated as of
+> 21 August 2026 and will be switched off on **1 November 2026**.
+>
+> - **Replacement:** https://openbesluitvorming.nl — search interface plus a
+>   documented REST API with bulk export and incremental synchronisation.
+> - **Migration guide:** https://openbesluitvorming.nl/docs/migration-guide
+> - **API reference:** https://openbesluitvorming.nl/docs/api
+> - **Blocked on something?** Open an issue on
+>   [ontola/openbesluitvorming](https://github.com/ontola/openbesluitvorming/issues),
+>   or mail sander.bakker@vng.nl.
+>
+> Until 1 November the existing endpoints keep working unchanged. After that date
+> this repository is archived and stays readable, and the data remains available
+> through OpenBesluitvorming.
+
 Open Raadsinformatie (ORI) aims to collect and standardize governmental decision making documents of Dutch municipalities (gemeenten, provincies, waterschappen).
 Open Raadsinformatie is a collaborative effort of the [Open State Foundation](https://openstate.eu/), [Ontola](https://ontola.io) and [VNG Realisatie](https://vngrealisatie.nl/).
 


### PR DESCRIPTION
**Draft — this is a proposal, not an announcement.** The date still needs confirming by VNG, and Sander Bakker (VNG) will send Open State Foundation a heads-up before anything is published. Opening it here so there is something concrete to react to.

## What this adds

A deprecation banner at the top of `README.md` and `API-docs.md`. Both are what a reuser reads before calling this API — `API-docs.md` especially, since it is where the Elastic endpoint is documented.

The banner states a date rather than an intention, names the replacement, and links the migration guide, so someone arriving from a search result has it all in one screen.

## The date

Proposed: **1 November 2026**, about ten weeks after the 21 August announcement.

The alternative on the table was 1 October. Three reasons to prefer November:

1. Six weeks is thin for a public API with an unknown number of reusers; eight to twelve weeks is the usual range.
2. Moving a sunset date later is harmless. Moving it earlier is not, so it is better to start late than to correct downward.
3. Purmerend, Leiden, Oegstgeest and Velsen currently exist *only* in the old stack — their suppliers no longer answer, so they cannot be re-imported and are being migrated across from ori3's Elasticsearch. Until that is finished, this API is the only public home those four organisations have.

Changing the date is a one-line edit in two places if VNG decides otherwise.

## Not in this PR

Three things belong with an end-of-life announcement but do not live in this repository:

- **`Deprecation` and `Sunset` response headers** (RFC 9745 / RFC 8594) on the running API. This is the machine-readable half of the notice: unattended scripts nobody reads the logs of will still record it.
- **One announced brownout**, e.g. one hour on 15 October. It is by far the most effective way to surface integrations nobody knows exist — they report themselves within the hour, rather than on 1 November when it is an incident instead of a test.
- **Archiving this repository** after the shutdown date, rather than deleting it, so the URLs in circulation keep resolving.

Happy to open those separately, or to drop any of them.